### PR TITLE
core: Add Status and GameVersion

### DIFF
--- a/bindings/c/c_ffi.cpp
+++ b/bindings/c/c_ffi.cpp
@@ -129,6 +129,15 @@ char *pcsx2ipc_version(PCSX2Ipc *v, bool batch) {
     }
 }
 
+PCSX2Ipc::EmuStatus pcsx2ipc_status(PCSX2Ipc* v, bool batch) {
+    if (batch) {
+        v->Status<true>();
+        return (PCSX2Ipc::EmuStatus)0;
+    } else {
+        return v->Status<false>();
+    }
+}
+
 char *pcsx2ipc_getgametitle(PCSX2Ipc *v, bool batch) {
     if (batch) {
         return v->GetGameTitle<true>();
@@ -150,6 +159,14 @@ char *pcsx2ipc_getgameuuid(PCSX2Ipc *v, bool batch) {
         return v->GetGameUUID<true>();
     } else {
         return v->GetGameUUID<false>();
+    }
+}
+
+char* pcsx2ipc_getgameversion(PCSX2Ipc* v, bool batch) {
+    if (batch) {
+        return v->GetGameVersion<true>();
+    } else {
+        return v->GetGameVersion<false>();
     }
 }
 

--- a/bindings/c/c_ffi.h
+++ b/bindings/c/c_ffi.h
@@ -72,6 +72,11 @@ EXPORT_LIB uint64_t pcsx2ipc_read(PCSX2Ipc *v, uint32_t address,
 EXPORT_LIB char *pcsx2ipc_version(PCSX2Ipc *v, bool batch);
 
 /**
+ * @see PCSX2Ipc::Status
+ */
+EXPORT_LIB PCSX2Ipc::EmuStatus pcsx2ipc_status(PCSX2Ipc* v, bool batch);
+
+/**
  * @see PCSX2Ipc::GetGameTitle
  */
 EXPORT_LIB char *pcsx2ipc_getgametitle(PCSX2Ipc *v, bool batch);
@@ -85,6 +90,11 @@ EXPORT_LIB char *pcsx2ipc_getgameid(PCSX2Ipc *v, bool batch);
  * @see PCSX2Ipc::GetGameUUID
  */
 EXPORT_LIB char *pcsx2ipc_getgameuuid(PCSX2Ipc *v, bool batch);
+
+/**
+ * @see PCSX2Ipc::GetGameVersion
+ */
+EXPORT_LIB char* pcsx2ipc_getgameversion(PCSX2Ipc* v, bool batch);
 
 /**
  * @see PCSX2Ipc::SaveState


### PR DESCRIPTION
Implements 2 new commands, Status and GameVersion and adds them to the C bindings. One thing, what is the correct return value from the C binding of `pcsx2ipc_status` when in batch mode?