### PR TITLE
Fix C bindings build

### DIFF
--- a/bindings/c/meson.build
+++ b/bindings/c/meson.build
@@ -1,4 +1,4 @@
-project('pine', 'cpp', default_options : ['cpp_std=c++17',
+project('pine', 'cpp', default_options : ['cpp_std=c++20',
 'buildtype=release'])
 add_global_arguments('-DC_FFI', language : 'cpp')
 


### PR DESCRIPTION
This commit bumps the C++ standard used to C++ 20 in the C bindings build. This removes various compilation errors that could happen with the C++ standard set to C++ 17 (at least they were happening to me, feel free to tell me if there's soemthing else i was doing wrong). 

C++17:
```
refrag@refrag-PC:~/src/pine/bindings/c$ meson build && cd build && ninja
The Meson build system
Version: 1.3.2
Source dir: /home/refrag/src/pine/bindings/c
Build dir: /home/refrag/src/pine/bindings/c/build
Build type: native build
Project name: pine
Project version: undefined
C++ compiler for the host machine: ccache c++ (gcc 13.2.0 "c++ (Ubuntu 13.2.0-23ubuntu4) 13.2.0")
C++ linker for the host machine: c++ ld.bfd 2.42
Host machine cpu family: x86_64
Host machine cpu: x86_64
Library ws2_32 found: NO
Run-time dependency threads found: YES
Program clang-format found: YES (/usr/bin/clang-format)
WARNING: You should add the boolean check kwarg to the run_command call.
         It currently defaults to false,
         but it will default to true in future releases of meson.
         See also: https://github.com/mesonbuild/meson/issues/9300
Build targets in project: 1

Found ninja-1.11.1 at /usr/bin/ninja
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
[1/2] Compiling C++ object libpine_c.so.p/c_ffi.cpp.o
FAILED: libpine_c.so.p/c_ffi.cpp.o 
ccache c++ -Ilibpine_c.so.p -I. -I.. -I../../../src -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++17 -O3 -DC_FFI -fPIC -pthread -MD -MQ libpine_c.so.p/c_ffi.cpp.o -MF libpine_c.so.p/c_ffi.cpp.o.d -o libpine_c.so.p/c_ffi.cpp.o -c ../c_ffi.cpp
In file included from ../c_ffi.h:14,
                 from ../c_ffi.cpp:1:
../../../src/pine.h:109:17: error: field ‘SOCKET_NAME’ has incomplete type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
  109 |     std::string SOCKET_NAME;
      |                 ^~~~~~~~~~~
In file included from /usr/include/c++/13/iosfwd:41,
                 from /usr/include/c++/13/bits/std_thread.h:38,
                 from /usr/include/c++/13/thread:45,
                 from ../../../src/pine.h:8:
/usr/include/c++/13/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}
   72 |     class basic_string;
      |           ^~~~~~~~~~~~
../../../src/pine.h:1073:55: error: ‘emulator_name’ has incomplete type
 1073 |     Shared(const unsigned int slot, const std::string emulator_name,
      |                                     ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
/usr/include/c++/13/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}
   72 |     class basic_string;
      |           ^~~~~~~~~~~~
../../../src/pine.h: In constructor ‘PINE::Shared::Shared(unsigned int, std::string, bool)’:
../../../src/pine.h:1102:39: error: ‘to_string’ is not a member of ‘std’
 1102 |             SOCKET_NAME += "." + std::to_string(slot);
      |                                       ^~~~~~~~~
../../../src/pine.h:24:1: note: ‘std::to_string’ is defined in header ‘<string>’; did you forget to ‘#include <string>’?
   23 | #include <unistd.h>
  +++ |+#include <string>
   24 | #endif
../../../src/pine.h: In constructor ‘PINE::PCSX2::PCSX2(unsigned int)’:
../../../src/pine.h:1135:66: error: no matching function for call to ‘PINE::Shared::Shared(unsigned int, const char [6], bool)’
 1135 |         : Shared((slot == 0) ? 28011 : slot, "pcsx2", (slot == 0)){};
      |                                                                  ^
../../../src/pine.h:1073:5: note: candidate: ‘PINE::Shared::Shared(unsigned int, std::string, bool)’
 1073 |     Shared(const unsigned int slot, const std::string emulator_name,
      |     ^~~~~~
../../../src/pine.h:1073:55: note:   no known conversion for argument 2 from ‘const char [6]’ to ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
 1073 |     Shared(const unsigned int slot, const std::string emulator_name,
      |                                     ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
../../../src/pine.h: In constructor ‘PINE::RPCS3::RPCS3(unsigned int)’:
../../../src/pine.h:1146:66: error: no matching function for call to ‘PINE::Shared::Shared(unsigned int, const char [6], bool)’
 1146 |         : Shared((slot == 0) ? 28012 : slot, "rpcs3", (slot == 0)){};
      |                                                                  ^
../../../src/pine.h:1073:5: note: candidate: ‘PINE::Shared::Shared(unsigned int, std::string, bool)’
 1073 |     Shared(const unsigned int slot, const std::string emulator_name,
      |     ^~~~~~
../../../src/pine.h:1073:55: note:   no known conversion for argument 2 from ‘const char [6]’ to ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
 1073 |     Shared(const unsigned int slot, const std::string emulator_name,
      |                                     ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
../../../src/pine.h: In constructor ‘PINE::DuckStation::DuckStation(unsigned int)’:
../../../src/pine.h:1157:72: error: no matching function for call to ‘PINE::Shared::Shared(unsigned int, const char [12], bool)’
 1157 |         : Shared((slot == 0) ? 28011 : slot, "duckstation", (slot == 0)){};
      |                                                                        ^
../../../src/pine.h:1073:5: note: candidate: ‘PINE::Shared::Shared(unsigned int, std::string, bool)’
 1073 |     Shared(const unsigned int slot, const std::string emulator_name,
      |     ^~~~~~
../../../src/pine.h:1073:55: note:   no known conversion for argument 2 from ‘const char [12]’ to ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
 1073 |     Shared(const unsigned int slot, const std::string emulator_name,
      |                                     ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
```

C++20:
```
refrag@refrag-PC:~/src/pine/bindings/c$ meson build && cd build && ninja
The Meson build system
Version: 1.3.2
Source dir: /home/refrag/src/pine/bindings/c
Build dir: /home/refrag/src/pine/bindings/c/build
Build type: native build
Project name: pine
Project version: undefined
C++ compiler for the host machine: ccache c++ (gcc 13.2.0 "c++ (Ubuntu 13.2.0-23ubuntu4) 13.2.0")
C++ linker for the host machine: c++ ld.bfd 2.42
Host machine cpu family: x86_64
Host machine cpu: x86_64
Library ws2_32 found: NO
Run-time dependency threads found: YES
Program clang-format found: YES (/usr/bin/clang-format)
WARNING: You should add the boolean check kwarg to the run_command call.
         It currently defaults to false,
         but it will default to true in future releases of meson.
         See also: https://github.com/mesonbuild/meson/issues/9300
Build targets in project: 1

Found ninja-1.11.1 at /usr/bin/ninja
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
[2/2] Linking target libpine_c.so
```