### PR TITLE
build: CMake (app + C FFI), Catch2 v3 tests, MSVC fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.10)
+project(pine LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Threads REQUIRED)
+
+add_executable(client src/client.cpp)
+target_link_libraries(client PRIVATE Threads::Threads)
+if(WIN32)
+  target_link_libraries(client PRIVATE ws2_32)
+endif()
+
+include(CTest)
+if(BUILD_TESTING)
+  find_package(Catch2 3 QUIET CONFIG)
+  if(TARGET Catch2::Catch2WithMain)
+    add_executable(tests src/tests.cpp)
+    target_compile_definitions(tests PRIVATE TESTS)
+    target_link_libraries(tests PRIVATE Catch2::Catch2WithMain)
+    if(WIN32)
+      target_link_libraries(tests PRIVATE ws2_32)
+    endif()
+    add_test(NAME tests COMMAND tests)
+  endif()
+endif()

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Meson and ninja ARE portable across OSes as-is and shouldn't require any tinkeri
 refer to [the meson documentation](https://mesonbuild.com/Using-with-Visual-Studio.html) 
 if you really want to use another generator, say, Visual Studio, instead of ninja.   
 
+You can also build with CMake from the repository root:  
+`cmake -S . -B build && cmake --build build`
+Run CTest against the build directory:
+`ctest --test-dir build`.
+
 On Doxygen you can find the documentation of the C++ API [here](@ref PINE).  
 The C API is documented [here](@ref bindings/c/c_ffi.h) and is probably what you
 want to read if you use language bindings.

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.10)
+project(pine_c LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Threads REQUIRED)
+
+add_library(pine_c SHARED c_ffi.cpp)
+target_compile_definitions(pine_c PRIVATE C_FFI)
+target_include_directories(pine_c
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../src>"
+  PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+target_link_libraries(pine_c PRIVATE Threads::Threads)
+if(WIN32)
+  target_link_libraries(pine_c PRIVATE ws2_32)
+endif()

--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -3,3 +3,6 @@ by C programs and much more by using the FFI of other programming languages.
 Refer to the [meson documentation](https://mesonbuild.com/) for how to build
 this library on your OS. Alternatively, if your OS is sane, running 
 `meson build && cd build && ninja` should build your library just fine.
+
+With CMake, from this directory:  
+`cmake -S . -B build && cmake --build build`

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ executable('client', src, dependencies : [thread_dep, winsock])
 
 
 
-catch2 = dependency('catch2', required : false)
+catch2 = dependency('catch2-with-main', required : false)
 test_src = ['src/tests.cpp']
 if catch2.found()
   # TODO: in the future if we need to add threads to the API test cases might

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -7,7 +7,15 @@
 #define u16 uint16_t
 #define u32 uint32_t
 #define u64 uint64_t
-#define u128 __int128
+
+// MSVC has no __int128.
+#if defined(_MSC_VER)
+struct alignas(16) u128 {
+    unsigned char raw[16];
+};
+#else
+using u128 = __int128;
+#endif
 
 /* Test case suite for the PCSX2 IPC API
  * You will probably need to set environment variables to be able
@@ -90,7 +98,7 @@ SCENARIO("PCSX2 can be interacted with remotely through IPC", "[pine]") {
                                      PINE::PCSX2::IPCBuffer{ 5, c_ret }));
 
                 // make unimplemented write
-                REQUIRE_THROWS(ipc->Write<u128>(0x00347D34, 5));
+                REQUIRE_THROWS(ipc->Write<u128>(0x00347D34, u128{}));
 
                 // make unimplemented read
                 REQUIRE_THROWS(ipc->Read<u128>(0x00347D34));

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -1,6 +1,5 @@
 #include "pine.h"
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <climits>
 
 #define u8 uint8_t

--- a/utils/default.nix
+++ b/utils/default.nix
@@ -34,6 +34,7 @@ pkgs.mkShell {
     pkgs.pkgconfig
     pkgs.xorg.xorgserver
     pkgs.meson
+    pkgs.cmake
     pkgs.ninja
     pkgs.gcovr
   ];


### PR DESCRIPTION
Add root and bindings/c CMake support. Update tests for Catch2 v3. And fix compiling on MSVC.